### PR TITLE
Improved number literals

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -36,9 +36,11 @@ highlight link swiftReserveKeywords Keyword
 
 " {{{ Literals
 " Integer literal
-syntax match swiftIntegerLiteral /\<[0-9a-fA-F\.]\+\>/
-syntax match swiftIntegerLiteral /\<0x[0-9]\+\>/
-syntax match swiftIntegerLiteral /\<0o[0-9]\+\>/
+syntax match swiftIntegerLiteral /\<\d\+\%(_\d\+\)*\%(\.\d\+\%(_\d\+\)*\)\=\>/
+syntax match swiftIntegerLiteral /\<\d\+\%(_\d\+\)*\%(\.\d\+\%(_\d\+\)*\)\=\%([eE][-+]\=\d\+\%(_\d\+\)*\)\>/
+syntax match swiftIntegerLiteral /\<0x\x\+\%(_\x\+\)*\>/
+syntax match swiftIntegerLiteral /\<0o\o\+\%(_\o\+\)*\>/
+syntax match swiftIntegerLiteral /\<0b[01]\+\%(_[01]\+\)*\>/
 highlight link swiftIntegerLiteral Number
 " String literal
 syntax region swiftStringLiteral start=/"/ skip=/\\"/ end=/"/

--- a/test/numeric_literals.swift
+++ b/test/numeric_literals.swift
@@ -1,4 +1,11 @@
 let decimalInteger = 17
-let binaryInteger = 0b10001       // 17 in binary notation
-let octalInteger = 0o21           // 17 in octal notation
-let hexadecimalInteger = 0x11     // 17 in hexadecimal notation
+let binaryInteger = 0b10001             // 17 in binary notation
+let octalInteger = 0o21                 // 17 in octal notation
+let hexadecimalInteger = 0x11           // 17 in hexadecimal notation
+let decimalInteger = 123_456_789
+let separatedBinaryInteger = 0b10_001
+let separatedOctalInteger = 0o21_17
+let separatedHexadecimalInteger = 0x1a_f1
+let pi = 3.141592
+let exponential = 1.21875e1
+let exponential2 = 1.21875e+1


### PR DESCRIPTION
I implemented highlights for underscore separators and exponential numbers.

``` swift
let separatedDecimalInteger = 123_456_789
let separatedBinaryInteger = 0b10_001
let separatedOctalInteger = 0o21_17
let separatedHexadecimalInteger = 0x1a_f1
let exponential = 1.21875e1
let exponential2 = 1.21875e+1
```
