### PR TITLE
Fix typo

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -15,8 +15,8 @@ highlight link swiftComment Comment
 " }}}
 
 " {{{ Identifiers
-syntax match swiftIdentifer /[[:alpha:]_][[:alnum:]_]*/
-highlight link swiftIdentifer Identifier
+syntax match swiftIdentifier /[[:alpha:]_][[:alnum:]_]*/
+highlight link swiftIdentifier Identifier
 " }}}
 
 " {{{ Keywords


### PR DESCRIPTION
Thank you for a great plugin!
I found a typo in Identifiers section.
